### PR TITLE
chore: add dependabot config for Go modules and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What changed

Added `.github/dependabot.yml` to enable weekly automated dependency update pull requests for:
- **Go modules** (`gomod` ecosystem) — covers `go.mod`/`go.sum` dependencies
- **GitHub Actions** (`github-actions` ecosystem) — covers action versions in `.github/workflows/`

## Why

The repo currently has no dependabot configuration despite having real Go dependencies and GitHub Actions workflows that are already falling behind:
- `docker/build-push-action` is pinned to `@v5`; current is `@v7`
- `rs/cors` is on `v1.10.1`; current is `v1.11.1`

Adding this file is a pure addition with zero code risk — dependabot only opens PRs, it never auto-merges.

## Verification

```
cat .github/dependabot.yml
```

Output confirms the file is valid YAML with correct `version: 2` schema, two update blocks (gomod and github-actions), both set to weekly cadence. No build steps required for a config-only addition.

---
*This is an automated maintenance pass by the ultracode scan agent.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `/.github/dependabot.yml` to enable weekly automated update PRs for `gomod` and `github-actions`, keeping Go modules and workflow actions current. This surfaces drift like `docker/build-push-action@v5` (current `@v7`) and `rs/cors v1.10.1` (current `v1.11.1`) without auto-merging.

<sup>Written for commit 1c9aabb7530cb51ee29bee7766f0a01d31a99ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/iplogger/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

