### PR TITLE
chore: migrate personal domain references to minpeter.uk

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ A study on how services located behind multiple reverse proxies log real client 
 
 ## screenshot
 
-[![image](https://user-images.githubusercontent.com/62207008/217578966-c1daa0b2-5040-4906-abe8-aa7a2f276956.png)](https://ip.minpeter.xyz)
+[![image](https://user-images.githubusercontent.com/62207008/217578966-c1daa0b2-5040-4906-abe8-aa7a2f276956.png)](https://ip.minpeter.uk)
 
 ## how to use?
 
 ```sh
-curl ip.minpeter.xyz -L
+curl ip.minpeter.uk -L
 ```
 
-or <https://ip.minpeter.xyz>
+or <https://ip.minpeter.uk>
 
 ## deployment
 
@@ -51,7 +51,7 @@ now running on <http://localhost:10000>
 ## ✨ result post ✨
 
 A brief [description](docs/result.md) of the project (Korean only)  
-[Blog post](https://minpeter.xyz/blog/how-loggin-real-ip) written while working on this projec (Korean only)
+[Blog post](https://minpeter.uk/blog/how-loggin-real-ip) written while working on this projec (Korean only)
 
 프로젝트에 대한 간단한 [설명 글](docs/result.md)  
-이 프로젝트를 진행하면서 작성한 [블로그 글](https://minpeter.xyz/blog/how-loggin-real-ip)
+이 프로젝트를 진행하면서 작성한 [블로그 글](https://minpeter.uk/blog/how-loggin-real-ip)


### PR DESCRIPTION
## Summary
개인 도메인 참조를 `minpeter.uk`로 통합하기 위해, 기존 개인 도메인(`minpeter.xyz`, `minpeter.tech`) 참조를 모두 `minpeter.uk`로 교체합니다.

## Changes
- `minpeter.xyz` -> `minpeter.uk`
- `minpeter.tech` -> `minpeter.uk`
- 서브도메인 포함 (예: `ip.minpeter.tech` -> `ip.minpeter.uk`)

## Affected files
- README.md

## Notes
- `minpeter.uk` 및 `minpeter.github.io` (GitHub Pages) 참조는 의도적으로 변경하지 않았습니다.
- `minpeter` 소유가 아닌 타 도메인(예: `ip.tmpf.me`)은 변경하지 않았습니다.
- 본 PR은 텍스트 참조 교체만 수행하며, DNS / 인증서 SAN / Cloudflare zone ID / 라우팅 설정 등은 별도 인프라 업데이트가 필요할 수 있습니다.

자동화된 도메인 마이그레이션(`minpeter.xyz`/`minpeter.tech` -> `minpeter.uk`) 일환으로 생성되었습니다.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all personal domain links in README from `minpeter.xyz`/`minpeter.tech` (including subdomains) to `minpeter.uk` to align docs with the new primary domain.

<sup>Written for commit e0bcb66ddd38003fafb740e7f20e59ab318f46d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/iplogger/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

