### PR TITLE
docs: fix typo in README (projec -> project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ now running on <http://localhost:10000>
 ## ✨ result post ✨
 
 A brief [description](docs/result.md) of the project (Korean only)  
-[Blog post](https://minpeter.uk/blog/how-loggin-real-ip) written while working on this projec (Korean only)
+[Blog post](https://minpeter.uk/blog/how-loggin-real-ip) written while working on this project (Korean only)
 
 프로젝트에 대한 간단한 [설명 글](docs/result.md)  
 이 프로젝트를 진행하면서 작성한 [블로그 글](https://minpeter.uk/blog/how-loggin-real-ip)


### PR DESCRIPTION
## Summary
`README.md` 의 오타 `projec` -> `project` 수정.

## Context
도메인 마이그레이션 PR #12 (minpeter.xyz -> minpeter.uk) 에 대해 Gemini Code Assist 가 남긴 리뷰에서 동일 라인의 오타를 지적했습니다. 해당 오타는 #12 와 무관하게 원래 존재하던 것이므로, 별도 PR로 분리해 수정합니다.

## Changes
- `README.md` (line 54): `this projec (Korean only)` -> `this project (Korean only)`

## Notes
- #12 은 이미 main 에 머지되었으므로 본 PR은 main 기반의 1-line diff 이며 충돌이 없습니다.
- 도메인 문자열(`minpeter.uk`)은 건드리지 않습니다.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix README typo: "this projec" -> "this project" in the result post section. No other changes; the domain link remains the same.

<sup>Written for commit 09b331d2285bfd83afbf2eed35d3bbff18900ed8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/iplogger/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

